### PR TITLE
Support namespaced components

### DIFF
--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -2,7 +2,11 @@ module ViewComponentReflex
   class Component < ViewComponent::Base
     class << self
       def init_stimulus_reflex
-        @stimulus_reflex ||= Object.const_set(name + "Reflex", Class.new(Reflex))
+        if name.include? "::"
+          @stimulus_reflex ||= module_parent.const_set(name.split("::").last + "Reflex", Class.new(Reflex))
+        else
+          @stimulus_reflex ||= Object.const_set(name + "Reflex", Class.new(Reflex))
+        end
         @stimulus_reflex.component_class = self
       end
     end


### PR DESCRIPTION
Hi!

Recently found this gem from a reference on the Stimulus Reflex doc pages and I'm loving it.

We use namespaces pretty heavily, and the code here was throwing errors like `NameError: wrong constant name` when using namespaced view components.

I'm not sure if this code will work in all cases but it seems to be working in our case.

