### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ ViewComponentReflex uses session for its state by default. To change this, add
 an initializer to `config/initializers/view_component_reflex.rb`.
 
 ```ruby
-ViewComponentReflex.configure do |config|
+ViewComponentReflex::Engine.configure do |config|
   config.state_adapter = YourAdapter
 end
 ```


### PR DESCRIPTION
Following the Readme instructions for the `state_adapter` configuration leads to an `undefined method 'configure' for ViewComponentReflex:Module` on server start.

The right configuration should be:

```ruby
ViewComponentReflex::Engine.configure do |config|
  config.state_adapter = YourAdapter
end
```

Great library by the way!