### PR TITLE
feat: add reflex_data_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,29 @@ This shares the same definition as `content_tag`, except it accepts a reflex as 
 
 Would add a click handler to the `increment` method on your component.
 
-To use a non-click event, specific that with `->` notiation
+To use a non-click event, specific that with `->` notation
 
 ```erb
 <%= reflex_tag "mouseenter->increment", :button, "Click me!" %>
 ```
+
+### reflex_data_attributes(reflex)
+
+This helper will give you the data attributes used in the reflex_tag above if you want to build your own elements.
+
+Build your own tag:
+
+```erb
+<%= link_to (image_tag photo.image.url(:medium)), data: reflex_data_attributes(:increment) %>
+```
+
+Render a ViewComponent
+
+```erb
+<%= render ButtonComponent.new(data: reflex_data_attributes(:increment)) %>
+```
+
+Make sure that you assign the reflex_data_attributes to the correct element in your component.
 
 ### collection_key
 If you're rendering a component as a collection with `MyComponent.with_collection(SomeCollection)`, you must define this method to return some unique value for the component.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Build your own tag:
 Render a ViewComponent
 
 ```erb
-<%= render ButtonComponent.new(data: reflex_data_attributes(:increment)) %>
+<%= render ButtonComponent.new(data: reflex_data_attributes("mouseenter->increment")) %>
 ```
 
 Make sure that you assign the reflex_data_attributes to the correct element in your component.

--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -54,20 +54,25 @@ module ViewComponentReflex
       @key = key
     end
 
-    def reflex_tag(reflex, name, content_or_options_with_block = {}, options = {}, escape = true, &block)
-      action, method = reflex.to_s.split("->")
+    # Helper to use to create the proper reflex data attributes for an element
+    def reflex_data_attributes(reflex)
+      action, method = reflex.to_s.split('->')
       if method.nil?
         method = action
-        action = "click"
+        action = 'click'
       end
-      data_attributes = {
+
+      {
         reflex: "#{action}->#{self.class.name}##{method}",
         key: key
       }
+    end
+
+    def reflex_tag(reflex, name, content_or_options_with_block = {}, options = {}, escape = true, &block)
       if content_or_options_with_block.is_a?(Hash)
-        merge_data_attributes(content_or_options_with_block, data_attributes)
+        merge_data_attributes(content_or_options_with_block, reflex_data_attributes(reflex))
       else
-        merge_data_attributes(options, data_attributes)
+        merge_data_attributes(options, reflex_data_attributes(reflex))
       end
       content_tag(name, content_or_options_with_block, options, escape, &block)
     end


### PR DESCRIPTION
I love this Gem! There was one moment I wanted to use a ViewComponent as a button instead of the handy reflex_tag and thought of a helper that would just return the needed data attributes. I know I could do this manually, but I like magic more 🧙‍♀️.

So I did this: Expose the data_attributes used in the reflex_tag to the outside so you can use it to use it with custom tag builders or other ViewComponents.

Let me know if it makes sense. Cheers