### PR TITLE
data-key blank in views due to html file detection

### DIFF
--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -49,7 +49,7 @@ module ViewComponentReflex
     def init_key
       # we want the erb file that renders the component. `caller` gives the file name,
       # and line number, which should be unique. We hash it to make it a nice number
-      key = caller.select { |p| p.include? ".html.erb" }[1]&.hash.to_s
+      key = caller.select { |p| p.match? /.\.html\.(haml|erb|slim)/ }[1]&.hash.to_s
       key += collection_key.to_s if collection_key
       @key = key
     end


### PR DESCRIPTION
Hi, love your gem. I ran into a fun issue, please see below.

Fixing issue where data-key would be blank in views, because the key generated by init key was an empty string. This is because the init_key
looks for the lowest .html.erb file in the call stack. For users of haml
or other templating engines besides erb (e.g. slim), this doesn't work
because these engines use different extensions (e.g. html.haml).

Suggested fix is less than ideal because it uses a regex and still only
matches erb, slim and haml. A better fix might  be to just match .html.
(in code: { |d| d.include? '.html.' }).