### PR TITLE
Require only Rails 5.2

### DIFF
--- a/view_component_reflex.gemspec
+++ b/view_component_reflex.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0.3", ">= 6.0.3.1"
+  spec.add_dependency "rails", "~> 5.2"
   spec.add_dependency "stimulus_reflex", "~> 3.3.0"
   spec.add_dependency "view_component"
 end


### PR DESCRIPTION
Both StimulusReflex and ViewComponent works in Rails 5.2, shouldn't this as well?