### PR TITLE
fix: dependency for Rails 6

### DIFF
--- a/view_component_reflex.gemspec
+++ b/view_component_reflex.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 5.2"
+  spec.add_dependency "rails", [">= 5.2", "< 7.0"]
   spec.add_dependency "stimulus_reflex", "~> 3.3.0"
   spec.add_dependency "view_component"
 end


### PR DESCRIPTION
I've encountered an issue with your library and found out, that I was not on the latest version...

`~> 5.2` is identical to `>= 5.2` and `< 6.0`

I kept it pessimistic at least for Rails 6 (`< 7.0`).

Thanks for this gem! 👏 