### PR TITLE
docs: update defaul state adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ end
 
 ## State
 
-By default, view_component_reflex stores component state in memory. You can optionally set the state adapter
-to use the session by changing `config.state_adapter` to `ViewComponentReflex::StateAdapter::Session`
+By default (since version `2.3.2`), view_component_reflex stores component state in session. You can optionally set the state adapter
+to use the memory by changing `config.state_adapter` to `ViewComponentReflex::StateAdapter::Memory`.
 
 ## Custom State Adapters
 


### PR DESCRIPTION
I know, that these kinds of PR could be problematic these days... so I hope you find this change worthy.

I tracked this change to version `2.3.2` where [the default state adapter was changed](https://my.diffend.io/gems/view_component_reflex/2.3.1/2.3.2). 

It caused me an issue with `draper` gem, which has `Proc` in object and can not be saved to the session (error `no _dump_data is defined for class Proc`).

I thought it would be nice to reflect this in the docs.