### PR TITLE
Add redis based adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ end
 ## Existing Fast Redis based State Adapter
 
 This adapter uses hmset and hgetall to reduce the number of operations. 
-This is also the recommended way if you using it AnyCable.
+This is the recommended adapter if you are using AnyCable.
 
 ```ruby
 ViewComponentReflex::Engine.configure do |config|

--- a/README.md
+++ b/README.md
@@ -272,6 +272,22 @@ ViewComponentReflex::Engine.configure do |config|
 end
 ```
 
+
+## Existing Fast Redis based State Adapter
+
+This adapter uses hmset and hgetall to reduce the number of operations. 
+This is also the recommended way if you using it AnyCable.
+
+```ruby
+ViewComponentReflex::Engine.configure do |config|
+  config.state_adapter = ViewComponentReflex::StateAdapter::Redis.new(
+      redis_opts: {
+          url: "redis://localhost:6379/1", driver: :hiredis
+      },
+      ttl: 3600)
+end
+```
+
 `YourAdapter` should implement 
 
 ```ruby

--- a/lib/view_component_reflex/state_adapter/memory.rb
+++ b/lib/view_component_reflex/state_adapter/memory.rb
@@ -20,6 +20,10 @@ module ViewComponentReflex
           VIEW_COMPONENT_REFLEX_MEMORY_STATE[request.session.id.to_s][key][k] = v
         end
       end
+
+      def self.wrap_write_async
+        yield
+      end
     end
   end
 end

--- a/lib/view_component_reflex/state_adapter/redis.rb
+++ b/lib/view_component_reflex/state_adapter/redis.rb
@@ -1,0 +1,66 @@
+# A redis based adapter for component_reflex
+#
+# ViewComponentReflex::Engine.configure do |config|
+#   config.state_adapter = ViewComponentReflex::StateAdapter::Redis.new(
+#       redis_opts: {
+#           url: "redis://localhost:6379/1", driver: :hiredis
+#       },
+#       ttl: 3600)
+# end
+
+module ViewComponentReflex
+  module StateAdapter
+    class Redis
+      attr_reader :client, :ttl
+
+      def initialize(redis_opts:, ttl: 3600)
+        @client = Redis.new(redis_opts)
+        @ttl = ttl
+      end
+
+      def state(request, key)
+        cache_key = get_key(request, key)
+        value = client.hgetall(cache_key)
+
+        return {} if value.nil?
+
+        value.map do |k, v|
+          [k, JSON.parse(v)]
+        end.to_h
+      end
+
+      def set_state(request, _, key, new_state)
+        cache_key = get_key(request, key)
+        save_to_redis(cache_key, new_state)
+      end
+
+      def store_state(request, key, new_state = {})
+        cache_key = get_key(request, key)
+        optimized_store_to_redis(cache_key, new_state, request)
+      end
+
+      # Reduce number of calls coming from #store_state to save Redis
+      # when it's first rendered
+      def optimized_store_to_redis(cache_key, new_state, request)
+        request.env["CACHE_REDIS_REFLEX"] ||= []
+        return if request.env["CACHE_REDIS_REFLEX"].include?(cache_key)
+        request.env["CACHE_REDIS_REFLEX"].push(cache_key)
+
+        save_to_redis(cache_key, new_state)
+      end
+
+      def save_to_redis(cache_key, new_state)
+        new_state_json = new_state.map do |k, v|
+          [k, v.to_json]
+        end
+
+        client.hmset(cache_key, new_state_json.flatten)
+        client.expire(cache_key, ttl)
+      end
+
+      def get_key(request, key)
+        "#{request.session.id.to_s}_#{key}_session_reflex_redis"
+      end
+    end
+  end
+end

--- a/lib/view_component_reflex/state_adapter/redis.rb
+++ b/lib/view_component_reflex/state_adapter/redis.rb
@@ -39,6 +39,14 @@ module ViewComponentReflex
         optimized_store_to_redis(cache_key, new_state, request)
       end
 
+      def wrap_write_async
+        client.pipelined do
+          yield
+        end
+      end
+
+      private
+
       # Reduce number of calls coming from #store_state to save Redis
       # when it's first rendered
       def optimized_store_to_redis(cache_key, new_state, request)

--- a/lib/view_component_reflex/state_adapter/redis.rb
+++ b/lib/view_component_reflex/state_adapter/redis.rb
@@ -14,7 +14,7 @@ module ViewComponentReflex
       attr_reader :client, :ttl
 
       def initialize(redis_opts:, ttl: 3600)
-        @client = Redis.new(redis_opts)
+        @client = ::Redis.new(redis_opts)
         @ttl = ttl
       end
 
@@ -25,7 +25,7 @@ module ViewComponentReflex
         return {} if value.nil?
 
         value.map do |k, v|
-          [k, JSON.parse(v)]
+          [k, Marshal.load(v)]
         end.to_h
       end
 
@@ -59,7 +59,7 @@ module ViewComponentReflex
 
       def save_to_redis(cache_key, new_state)
         new_state_json = new_state.map do |k, v|
-          [k, v.to_json]
+          [k, Marshal.dump(v)]
         end
 
         client.hmset(cache_key, new_state_json.flatten)

--- a/lib/view_component_reflex/state_adapter/session.rb
+++ b/lib/view_component_reflex/state_adapter/session.rb
@@ -19,6 +19,10 @@ module ViewComponentReflex
           request.session[key][k] = v
         end
       end
+
+      def self.wrap_write_async
+        yield
+      end
     end
   end
 end


### PR DESCRIPTION
uses hmset and hgetall to reduce the number of operations.

also added `#optimized_store_to_redis` because I've seen multiple calls to `#store_state` on the first render.
I'm using it with anycable atm