### PR TITLE
Selector morph gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ $ gem install view_component_reflex
 ## Uninitialized constants \<component\>Reflex
 A component needs to be wrapped in `<%= component_controller do %>` in order to properly initialize, otherwise the Reflex class won't get created.
 
+## Session is an empty hash
+StimulusReflex 3.3 introduced _selector morphs_, allowing you to render arbitrary strings via `ApplicationController.render`, for example:
+
+```rb
+def test_selector
+  morph '#some-container', ApplicationController.render(MyComponent.new(some: :param))
+end
+```
+
+StimulusReflex 3.4 introduced a fix that merges the current `request.env` and provides the CSRF token to fetch the session.
+
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It builds upon [stimulus_reflex](https://github.com/hopsoft/stimulus_reflex) and
 
 ## Usage
 
-You can add reflexes to your component by adding inheriting from `ViewComponentReflex::Component`.
+You can add reflexes to your component by inheriting from `ViewComponentReflex::Component`.
 
 This will act as if you created a reflex with the method `my_cool_stuff`. To call this reflex, add `data-reflex="click->MyComponentReflex#my_cool_reflex"`, just like you're
 using stimulus reflex.

--- a/view_component_reflex.gemspec
+++ b/view_component_reflex.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", [">= 5.2", "< 7.0"]
-  spec.add_dependency "stimulus_reflex", "~> 3.3.0"
+  spec.add_dependency "stimulus_reflex", ">= 3.3.0"
   spec.add_dependency "view_component"
 end


### PR DESCRIPTION
I ran into an issue morphing a VCR into existence using a selector morph. I found out that `request.session` was an empty hash in `Adapter::store_state`.

In SR 3.4.0 a fix was introduced to merge the `connection.env` back into the `controller.renderer`: https://github.com/hopsoft/stimulus_reflex/blob/master/app/channels/stimulus_reflex/channel.rb#L104

So to make this work we need to allow 3.4.0 in VCR, which this PR introduces.