### PR TITLE
Fix global state sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,23 +272,6 @@ ViewComponentReflex::Engine.configure do |config|
 end
 ```
 
-
-## Existing Fast Redis based State Adapter
-
-This adapter uses hmset and hgetall to reduce the number of operations. 
-This is the recommended adapter if you are using AnyCable.
-
-```ruby
-ViewComponentReflex::Engine.configure do |config|
-  config.state_adapter = ViewComponentReflex::StateAdapter::Redis.new(
-      redis_opts: {
-          url: "redis://localhost:6379/1", driver: :hiredis
-      },
-      ttl: 3600)
-end
-```
-
-
 ## Existing Fast Redis based State Adapter
 
 This adapter uses hmset and hgetall to reduce the number of operations. 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ ViewComponentReflex::Engine.configure do |config|
   config.state_adapter = YourAdapter
 end
 ```
+
+
 ## Existing Fast Redis based State Adapter
 
 This adapter uses hmset and hgetall to reduce the number of operations. 

--- a/README.md
+++ b/README.md
@@ -271,11 +271,10 @@ ViewComponentReflex::Engine.configure do |config|
   config.state_adapter = YourAdapter
 end
 ```
-
 ## Existing Fast Redis based State Adapter
 
 This adapter uses hmset and hgetall to reduce the number of operations. 
-This is also the recommended way if you using it AnyCable.
+This is the recommended adapter if you are using AnyCable.
 
 ```ruby
 ViewComponentReflex::Engine.configure do |config|

--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ ViewComponentReflex::Engine.configure do |config|
 end
 ```
 
+
+## Existing Fast Redis based State Adapter
+
+This adapter uses hmset and hgetall to reduce the number of operations. 
+This is also the recommended way if you using it AnyCable.
+
+```ruby
+ViewComponentReflex::Engine.configure do |config|
+  config.state_adapter = ViewComponentReflex::StateAdapter::Redis.new(
+      redis_opts: {
+          url: "redis://localhost:6379/1", driver: :hiredis
+      },
+      ttl: 3600)
+end
+```
+
 `YourAdapter` should implement 
 
 ```ruby

--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -101,7 +101,12 @@ module ViewComponentReflex
         ""
       end
       key += collection_key.to_s if collection_key
+      key += global_key.to_s if global_key
       @key = key
+    end
+
+    def global_key
+      request.session.id
     end
 
     # Helper to use to create the proper reflex data attributes for an element

--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -106,7 +106,7 @@ module ViewComponentReflex
     end
 
     def global_key
-      request.session.id
+      request.session[:global_reflex_cookie_id] ||= SecureRandom.hex
     end
 
     # Helper to use to create the proper reflex data attributes for an element


### PR DESCRIPTION
Currently, the state is shared between 2 browser windows, even on different machines.

In most cases, we might want to avoid that. But there can be cases where having sync is worthwhile.

if `#global_key` is the same between two clients, the state is being shared.