### PR TITLE
Draft: Deterministic data-key for each Component

### DIFF
--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -84,13 +84,8 @@ module ViewComponentReflex
     def init_key
       # we want the erb file that renders the component. `caller` gives the file name,
       # and line number, which should be unique. We hash it to make it a nice number
-      erb_file = caller.select { |p| p.match? /.\.html\.(haml|erb|slim)/ }[1]
-      key = if erb_file
-        Digest::SHA2.hexdigest(erb_file.split(":in")[0])
-      else
-        ""
-      end
-      key += collection_key.to_s if collection_key
+      key = Digest::SHA2.hexdigest(__FILE__)
+      key = "#{key}::#{collection_key}" if collection_key
       @key = key
     end
 

--- a/test/dummy/test/components/component_component_test.rb
+++ b/test/dummy/test/components/component_component_test.rb
@@ -31,7 +31,7 @@ class ComponentComponentTest < ViewComponent::TestCase
 
   def assert_component
     assert_equal(
-      %(<div data-controller="component" data-key="">\n  <span>Hello!</span>\n</div>),
+      %(<div data-controller="component" data-key="06ef6e37c7dce93cb53a33e68b7fa62b14cd655dd218e8605844fa2967ff3bf1">\n  <span>Hello!</span>\n</div>),
       render_inline(ComponentComponent.new).to_html
     )
   end


### PR DESCRIPTION
Allows any Component to be rendered at any time, including ActiveJobs.

    c = DemoComponent.new
    puts ApplicationController.render(c, layout: false)

Result would be similar to:

    <div data-controller="demo" data-key="06ef6e37c7dce93cb53a33e68b7fa62b14cd655dd218e8605844fa2967ff3bf1">
    <div>Add Demo template here</div>
    </div>

Addditionally, Components with #collection_key have their their data-key
created with a :: divider to assist with debugging
data-keys with or without a working #collection_key

For example, if DemoComponent#collection_key was 123, then
data-key="06ef6e37c7dce93cb53a33e68b7fa62b14cd655dd218e8605844fa2967ff3bf1::123"

An example usage within an ActiveJob's #perform method might be:

    demo = DemoComponent.new(thing: @thing)
    stimulus_controller = demo.class.stimulus_controller
    key = demo.init_key
    selector = %Q{[data-controller~="#{stimulus_controller}"][data-key="#{key}"]}

    cable_ready[DemosChannel].outer_html({
      selector: selector,
      html: ApplicationController.render(demo, layout: false)
    })
    cable_ready[DemosChannel].dispatch_event.broadcast_to(workflow)