### PR TITLE
fix: added @original_view_context to the unsafe instance variables

### DIFF
--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -216,6 +216,7 @@ module ViewComponentReflex
         :@helpers, :@controller, :@request, :@tag_builder, :@state_initialized,
         :@_content_evaluated, :@_render_in_block, :@__vc_controller, :@__vc_helpers,
         :@__cached_content, :@__vc_variant, :@__vc_content_evaluated, :@__vc_render_in_block,
+        :@original_view_context,
       ]
     end
 


### PR DESCRIPTION
I was getting a SystemStackError stack level too deep
see https://github.com/github/view_component/issues/1127

the cause was the missing removal of this instance variable