### PR TITLE
Automatically omit internal view component ivars

### DIFF
--- a/app/components/view_component_reflex/component.rb
+++ b/app/components/view_component_reflex/component.rb
@@ -204,7 +204,7 @@ module ViewComponentReflex
     # end
 
     def safe_instance_variables
-      instance_variables - unsafe_instance_variables - omitted_from_state
+      instance_variables.reject { |ivar| ivar.start_with?("@__vc") } - unsafe_instance_variables - omitted_from_state
     end
 
     private
@@ -214,8 +214,7 @@ module ViewComponentReflex
         :@view_context, :@lookup_context, :@view_renderer, :@view_flow,
         :@virtual_path, :@variant, :@current_template, :@output_buffer, :@key,
         :@helpers, :@controller, :@request, :@tag_builder, :@state_initialized,
-        :@_content_evaluated, :@_render_in_block, :@__vc_controller, :@__vc_helpers,
-        :@__cached_content, :@__vc_variant, :@__vc_content_evaluated, :@__vc_render_in_block,
+        :@_content_evaluated, :@_render_in_block, :@__cached_content,
         :@original_view_context,
       ]
     end


### PR DESCRIPTION
This changes the logic in `safe_instance_variables` to automatically
filter out instance variables that start with `@__vc` since that denotes
an internal ivar that shouldn't be used outside of view component
internals.

This should help prevent any conflicts/issues when view component adds
new internal attributes.
