### PR TITLE
fix: resolved redis client warning about pipelined

### DIFF
--- a/lib/view_component_reflex/state_adapter/redis.rb
+++ b/lib/view_component_reflex/state_adapter/redis.rb
@@ -11,7 +11,8 @@
 module ViewComponentReflex
   module StateAdapter
     class Redis < Base
-      attr_reader :client, :ttl
+      attr_reader :ttl
+      attr_accessor :client
 
       def initialize(redis_opts:, ttl: 3600)
         @client = ::Redis.new(redis_opts)
@@ -40,8 +41,11 @@ module ViewComponentReflex
       end
 
       def wrap_write_async
-        client.pipelined do
+        client.pipelined  do |pipeline|
+          original_client = client
+          @client = pipeline
           yield
+          @client = original_client
         end
       end
 


### PR DESCRIPTION
the original warning was:
(called from /app/vendor/bundle/ruby/3.1.0/gems/view_component_reflex-3.1.14.pre7/lib/view_component_reflex/state_adapter/redis.rb:43:in `wrap_write_async'}
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end

(called from /app/vendor/bundle/ruby/3.1.0/gems/view_component_reflex-3.1.14.pre7/lib/view_component_reflex/state_adapter/redis.rb:43:in `wrap_write_async'}